### PR TITLE
Showcase OpenMP support for Pythran

### DIFF
--- a/julia/julia_python.py
+++ b/julia/julia_python.py
@@ -19,6 +19,7 @@ def julia_python_for_loops(cr, ci, N, bound=1.5, lim=1000., cutoff=1e6):
     '''
     julia = np.empty((N, N), dtype=np.uint32)
     grid_x = np.linspace(-bound, bound, N)
+    #"omp parallel for private(i, x, j, y)"
     for i, x in enumerate(grid_x):
         for j, y in enumerate(grid_x):
             julia[i,j] = kernel(x, y, cr, ci, lim, cutoff=cutoff)

--- a/julia/julia_pythran.py
+++ b/julia/julia_pythran.py
@@ -21,10 +21,12 @@ source = '\n'.join(sources)
 # patch them
 source = re.sub(r'cutoff=cutoff', 'cutoff', source)
 source = re.sub(r'dtype=np.uint32', 'np.uint32', source)
+source = re.sub(r'#"omp', '"omp', source)
 
 # compile to a native module
 native = compile_pythrancode(modname,
-                             '\n'.join([imports, exports, source]))
+                             '\n'.join([imports, exports, source]),
+                             cxxflags=['-O2', '-fopenmp'])
 
 # load it
 native = imp.load_dynamic(modname, native)

--- a/pairwise/__init__.py
+++ b/pairwise/__init__.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def make_env(shape=(200, 100), seed=0, dtype=np.double):
+def make_env(shape=(300, 150), seed=0, dtype=np.double):
     rng = np.random.RandomState(seed)
     data = np.asarray(rng.normal(size=shape), dtype=dtype)
     return (data,), {}

--- a/pairwise/pairwise_python.py
+++ b/pairwise/pairwise_python.py
@@ -7,6 +7,7 @@ import numpy as np
 def pairwise_python_nested_for_loops(data):
     n_samples, n_features = data.shape
     distances = np.empty((n_samples, n_samples), dtype=data.dtype)
+    #"omp parallel for private(j, d, k, tmp)"
     for i in range(n_samples):
         for j in range(n_samples):
             d = 0.0

--- a/pairwise/pairwise_pythran.py
+++ b/pairwise/pairwise_pythran.py
@@ -17,10 +17,13 @@ source = getsource(pairwise_python.pairwise_python_nested_for_loops)
 
 # a few rewriting rules to prune unsupported features
 source = re.sub(r'dtype=data.dtype', 'np.double', source)
+source = re.sub(r'#"omp', '"omp', source)
 
 # compile to a native module
 native = compile_pythrancode(modname,
-                             '\n'.join([imports, exports, source]))
+                             '\n'.join([imports, exports, source]),
+                             cxxflags=['-O2', '-fopenmp']
+                             )
 
 # load it
 native = imp.load_dynamic(modname, native)


### PR DESCRIPTION
Rely on string annotation for explicit parallelism. Use comments instead
of string to avoid disturbing other compilers.

Also increases the pairwise problem size to make the speed difference more
obvious
