### PR TITLE
Make arc distance test size bigger to better show the difference.

### DIFF
--- a/arc_distance/__init__.py
+++ b/arc_distance/__init__.py
@@ -13,7 +13,7 @@ See also http://en.wikipedia.org/wiki/Great-circle_distance
 import numpy as np
 
 
-def make_env(n=100):
+def make_env(n=1000):
     rng = np.random.RandomState(42)
     a = rng.rand(n, 2)
     b = rng.rand(n, 2)


### PR DESCRIPTION
Now on the web site, 5 on the 7 test case have speed of 0.001, the minimal value.
