### PR TITLE
rosen_der no longer segfaults in Parakeet

### DIFF
--- a/arc_distance/arc_distance_parakeet.py
+++ b/arc_distance/arc_distance_parakeet.py
@@ -1,4 +1,4 @@
-# Authors: Yuancheng Peng
+# Authors: Alex Rubinsteyn
 # License: MIT
 
 from arc_distance import arc_distance_python as adp

--- a/arc_distance/arc_distance_parakeet.py
+++ b/arc_distance/arc_distance_parakeet.py
@@ -1,0 +1,10 @@
+# Authors: Yuancheng Peng
+# License: MIT
+
+from arc_distance import arc_distance_python as adp
+from parakeet import jit
+
+
+benchmarks = (("arc_distance_parakeet_for_loops",
+               jit(adp.arc_distance_python_nested_for_loops)),
+              )

--- a/rosen_der/rosen_der_parakeet.py
+++ b/rosen_der/rosen_der_parakeet.py
@@ -4,8 +4,7 @@
 from rosen_der import rosen_der_python
 from parakeet import jit
 
-# makes the whole engine segfault...
-# benchmarks = (
-#     ("rosen_der_parakeet",
-#      jit(rosen_der_python.rosen_der_python)),
-# )
+benchmarks = (
+     ("rosen_der_loops_parakeet", jit(rosen_der_python.rosen_der_python)),
+     ("rosen_der_numpy_parakeet", jit(rosen_der_python.rosen_der_numpy))
+ )


### PR DESCRIPTION
Negative indexing no longer crashes Parakeet (at least not in the obvious cases)
